### PR TITLE
Fix extra whitespace in reservation.css

### DIFF
--- a/src/main/resources/static/css/reservation.css
+++ b/src/main/resources/static/css/reservation.css
@@ -222,7 +222,7 @@ button:hover{
   background: linear-gradient(to top,  rgb(217, 237, 255), rgb(210, 225, 255));
   transform: translateY(-5px);
   box-shadow: 0 5px 12px rgba(0, 0, 0, 0.2);
-}
+} 
 
 rt{
    /*후리가나 크기 줄이기*/


### PR DESCRIPTION
Removed unnecessary whitespace after button:hover selector to maintain consistent formatting in the CSS file.