### PR TITLE
Enhance sign-in form with country map and datepicker

### DIFF
--- a/src/main/java/com/KOKUAirLine/project/controller/SigninControlller.java
+++ b/src/main/java/com/KOKUAirLine/project/controller/SigninControlller.java
@@ -21,33 +21,37 @@ import jakarta.validation.Valid;
 
 @Controller
 public class SigninControlller {
+	
+	private final UserInfoRepo userInfoRepository;
+
+    public SigninControlller(UserInfoRepo userInfoRepository) {
+        this.userInfoRepository = userInfoRepository;
+    }
+	
+	@ModelAttribute("countryMap")
+	public Map<String, String> countryMap() {
+	    String[] countryCodes = Locale.getISOCountries();
+	    Map<String, String> countryMap = new LinkedHashMap<>();
+	    for (String code : countryCodes) {
+	        Locale locale = new Locale("", code);
+	        countryMap.put(code, locale.getDisplayCountry(Locale.JAPAN));
+	    }
+	    return countryMap;
+	}
 
 	@GetMapping("/signin")
 	public String showSigninForm(Model model) {
 	    model.addAttribute("userInfo", new UserInfo());
 
-	    String[] countryCodes = Locale.getISOCountries();
-	    Map<String, String> countryMap = new LinkedHashMap<>();
-	    for (String code : countryCodes) {
-	        Locale locale = new Locale("", code);
-	        countryMap.put(code, locale.getDisplayCountry(Locale.JAPAN)); // 일본어로 국가명
-	    }
-	    model.addAttribute("countryMap", countryMap);
-
 	    return "signin";
 	}
-    
-    private final UserInfoRepo userInfoRepository;
-
-    public SigninControlller(UserInfoRepo userInfoRepository) {
-        this.userInfoRepository = userInfoRepository;
-    }
 
     @PostMapping("/signin")
     public String signin(
         @Valid @ModelAttribute("userInfo") UserInfo userInfo,
         BindingResult bindingResult,
-        RedirectAttributes redirectAttributes
+        RedirectAttributes redirectAttributes,
+        Model model
     ) {
         // 유효성 검사 실패 시 다시 폼으로
         if (bindingResult.hasErrors()) {
@@ -57,7 +61,7 @@ public class SigninControlller {
 
         // ID 중복 확인
         if (userInfoRepository.existsById(userInfo.getUserId())) {
-            redirectAttributes.addFlashAttribute("error", "이미 사용 중인 ID입니다.");
+            redirectAttributes.addFlashAttribute("error", "すでに使用中のIDです。");
             return "redirect:/signin";
         }
 

--- a/src/main/webapp/WEB-INF/views/signin.jsp
+++ b/src/main/webapp/WEB-INF/views/signin.jsp
@@ -63,15 +63,21 @@
     </form:select>
     <form:errors path="national" cssClass="error-message" />
 
-    <label for="caldateField"><ruby><rb>生年月日</rb><rt>せいねんがっぴ</rt></ruby></label>
-    <div>
-      <p class="birthinfo"><ruby><rb>会員登録</rb><rt>かいいんとうろく</rt></ruby>は１２<ruby><rb>歳</rb><rt>さい</rt></ruby><ruby><rb>以上</rb><rt>いじょう</rt></ruby><ruby><rb>可能</rb><rt>かのう</rt></ruby></p>
-    </div>
-    <div>
-      <form:input path="birthDate" type="text" id="caldateField" name="birthdate" readonly=""/>
-      <form:errors path="birthDate" cssClass="error-message" />
-    </div>
-
+    <label for="caldateField">
+	  <ruby><rb>生年月日</rb><rt>せいねんがっぴ</rt></ruby>
+		</label>
+		<div>
+		  <p class="birthinfo">
+		    <ruby><rb>会員登録</rb><rt>かいいんとうろく</rt></ruby>は１２
+		    <ruby><rb>歳</rb><rt>さい</rt></ruby>
+		    <ruby><rb>以上</rb><rt>いじょう</rt></ruby>
+		    <ruby><rb>可能</rb><rt>かのう</rt></ruby>
+		  </p>
+		</div>
+		<div>
+		  <form:input path="birthDate" id="caldateField" readonly="true" />
+		  <form:errors path="birthDate" cssClass="error-message" />
+		</div>
 
       <!-- 약관 동의 자리 -->
       <div class="terms-section">
@@ -133,6 +139,23 @@
       loadSectionFromHTML(termsFile, "privacy-policy", "terms-content-6");
     });
   </script>
+  <script>
+	  $(function () {
+	    $("#caldateField").datepicker({
+	      dateFormat: "yy-mm-dd", // LocalDate와 호환
+	      changeYear: true,
+	      changeMonth: true,
+	      yearRange: "1900:2025",
+	      maxDate: "-12Y", // 12세 이상만 선택 가능
+	      defaultDate: "-20Y",
+	      showAnim: "fadeIn"
+	    });
+	
+	    // 일본어 로케일 적용 (이미 i18n/datepicker-ja.min.js를 불러왔으므로)
+	    $.datepicker.setDefaults($.datepicker.regional["ja"]);
+	  });
+	</script>
+  
 </body>
 </html>
 


### PR DESCRIPTION
Refactored SigninControlller to provide a country map for the sign-in form and improved error messaging. Updated signin.jsp to use a jQuery datepicker for the birth date field, ensuring only users 12 years or older can register, and applied Japanese locale settings.